### PR TITLE
Tickets/dm 39904

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,14 @@
 Version History
 ===============
 
+v0.9.0
+-------
+
+* Remove the ``M2.set_mount_elevation_in_position_callback()``.
+* Ignore the events and telemetry that are not in **ts_xml** temporarily.
+* Communicate with the cRIO directly.
+* Add the enum field: ``ErrorCode.InterlockEngaged``.
+
 v0.8.2
 -------
 

--- a/python/lsst/ts/m2/csc.py
+++ b/python/lsst/ts/m2/csc.py
@@ -30,10 +30,13 @@ import numpy as np
 from lsst.ts import salobj
 from lsst.ts.idl.enums import MTM2
 from lsst.ts.m2com import (
+    DEFAULT_ENABLED_FAULTS_MASK,
     LIMIT_FORCE_AXIAL_CLOSED_LOOP,
     LIMIT_FORCE_TANGENT_CLOSED_LOOP,
+    ClosedLoopControlMode,
     ControllerCell,
-    MsgType,
+    DigitalOutputStatus,
+    PowerType,
 )
 from lsst.ts.m2com import __version__ as __m2com_version__
 
@@ -84,6 +87,12 @@ class M2(salobj.ConfigurableCsc):
         Namespace with configuration values.
     mtmount : `lsst.ts.salobj.Remote`
         Remote object of MTMount CSC.
+    ilc_retry_times : `int`
+        Retry times to transition the inner-loop controller (ILC) state.
+    ilc_timeout : `float`
+        Timeout in second for the transition of ILC state.
+    system_is_ready : `bool`
+        System is ready or not.
     """
 
     # Class attributes comes from the upstream BaseCsc class
@@ -93,6 +102,9 @@ class M2(salobj.ConfigurableCsc):
     # Command timeout in second
     COMMAND_TIMEOUT = 10
     COMMAND_TIMEOUT_LONG = 60
+
+    # Short sleep time in second
+    SLEEP_TIME_SHORT = 3.0
 
     def __init__(
         self,
@@ -136,13 +148,13 @@ class M2(salobj.ConfigurableCsc):
         self.config: types.SimpleNamespace | None = None
 
         # Remote to listen to MTMount position
-        self.mtmount = salobj.Remote(
-            self.domain, "MTMount", include=["elevation", "elevationInPosition"]
-        )
+        self.mtmount = salobj.Remote(self.domain, "MTMount", include=["elevation"])
         self.mtmount.tel_elevation.callback = self.set_mount_elevation_callback
-        self.mtmount.evt_elevationInPosition.callback = (
-            self.set_mount_elevation_in_position_callback
-        )
+
+        self.ilc_retry_times = 3
+        self.ilc_timeout = 20.0
+
+        self.system_is_ready = False
 
         # Software version of the M2 common module
         self.evt_softwareVersions.set(subsystemVersions=f"ts-m2com={__m2com_version__}")
@@ -158,29 +170,6 @@ class M2(salobj.ConfigurableCsc):
 
         if self.controller_cell.are_clients_connected():
             await self.controller_cell.set_external_elevation_angle(data.actualPosition)
-
-    async def set_mount_elevation_in_position_callback(
-        self, data: salobj.BaseMsgType
-    ) -> None:
-        """Callback function to notify the mount elevation in position.
-
-        .. deprecated:: 0.8.0
-            This function will be removed after the CSC communicates with the
-            cRIO directly.
-
-        Parameters
-        ----------
-        data : `object`
-            Data of the SAL message.
-        """
-
-        if self.controller_cell.are_clients_connected():
-            await self.controller_cell.client_command.write_message(
-                MsgType.Event,
-                "mountInPosition",
-                msg_details=dict(inPosition=data.inPosition),
-                comp_name="MTMount",
-            )
 
     async def configure(self, config: types.SimpleNamespace) -> None:
         """Configure CSC.
@@ -243,18 +232,46 @@ class M2(salobj.ConfigurableCsc):
             Message from the M2 controller. (the default is None)
         """
 
+        is_interlock_engaged = False
+
         # Publish the SAL event
         if isinstance(message, dict):
+            # Bypass the following events before we support them in ts_xml
+            if message["id"] in (
+                "scriptExecutionStatus",
+                "digitalOutput",
+                "digitalInput",
+                "config",
+                "openLoopMaxLimit",
+                "limitSwitchStatus",
+                "powerSystemState",
+                "closedLoopControlMode",
+                "innerLoopControlMode",
+                "summaryFaultsStatus",
+                "enabledFaultsMask",
+                "configurationFiles",
+            ):
+                return
+
             await self._publish_message_by_sal("evt_", message)
 
-        # Fault the CSC if the controller is in Fault
-        if (self.controller_cell.controller_state == salobj.State.FAULT) and (
-            self.summary_state != salobj.State.FAULT
-        ):
-            await self.fault(
-                code=ErrorCode.ControllerInFault,
-                report="Controller's state is Fault.",
-            )
+            # Check the interlock status
+            if (message["id"] == "interlock") and (message["state"] is True):
+                is_interlock_engaged = True
+
+        # Fault the CSC when needed
+        if self.system_is_ready and (self.summary_state != salobj.State.FAULT):
+            if self.controller_cell.error_handler.exists_error():
+                await self.fault(
+                    code=ErrorCode.ControllerInFault,
+                    report="Controller's state is Fault.",
+                )
+
+            if is_interlock_engaged:
+                await self.fault(
+                    code=ErrorCode.InterlockEngaged,
+                    report="Interlock is engaged.",
+                )
 
     async def _publish_message_by_sal(
         self, prefix_sal_topic: str, message: dict
@@ -299,6 +316,14 @@ class M2(salobj.ConfigurableCsc):
 
         # Publish the SAL telemetry
         if isinstance(message, dict):
+            # Bypass the following telemetry before we support them in ts_xml
+            if message["id"] in (
+                "inclinometerAngleTma",
+                "powerStatusRaw",
+                "forceErrorTangent",
+            ):
+                return
+
             await self._publish_message_by_sal("tel_", message)
 
     async def _process_lost_connection(self) -> None:
@@ -319,6 +344,16 @@ class M2(salobj.ConfigurableCsc):
         await super().do_start(data)
 
         await self._connect_server(self.COMMAND_TIMEOUT)
+
+        # Wait for some time to process the welcome messages
+        await asyncio.sleep(self.SLEEP_TIME_SHORT)
+
+        # Clear all the existed error if any
+        if self.controller_cell.error_handler.exists_error():
+            await self._clear_controller_errors()
+
+        # Sleep for some time to process the messages
+        await asyncio.sleep(self.SLEEP_TIME_SHORT)
 
     async def _connect_server(self, timeout: float) -> None:
         """Connect the TCP/IP server.
@@ -350,10 +385,35 @@ class M2(salobj.ConfigurableCsc):
         await super().begin_standby(data)
 
     async def do_standby(self, data: salobj.BaseMsgType) -> None:
+        # By doing this, we can avoid the new error code put the system into
+        # the Fault state again, which is annoying.
+        self.system_is_ready = False
+        await asyncio.sleep(self.SLEEP_TIME_SHORT)
+
         # Try to clear the error if any
-        if self.controller_cell.controller_state == salobj.State.FAULT:
+        if self.controller_cell.error_handler.exists_error():
             try:
                 await self._clear_controller_errors()
+
+            except Exception as error:
+                self.log.warning(
+                    f"Ignoring the error when clearing the controller's errors: {error}."
+                )
+
+        # Cleaning up
+        if self.controller_cell.are_clients_connected():
+            try:
+                await self._execute_command(
+                    self.controller_cell.power,
+                    PowerType.Communication,
+                    False,
+                    timeout=self.COMMAND_TIMEOUT_LONG,
+                )
+                await self._execute_command(
+                    self.controller_cell.set_closed_loop_control_mode,
+                    ClosedLoopControlMode.Idle,
+                    timeout=self.COMMAND_TIMEOUT_LONG,
+                )
 
             except Exception as error:
                 self.log.warning(
@@ -370,18 +430,168 @@ class M2(salobj.ConfigurableCsc):
     async def do_enable(self, data: salobj.BaseMsgType) -> None:
         await self.cmd_enable.ack_in_progress(data, timeout=self.COMMAND_TIMEOUT_LONG)
 
-        timeout = self.COMMAND_TIMEOUT
+        await self._bypass_monitor_ilc_read_error()
 
-        await self._transition_controller_state(
-            salobj.State.OFFLINE, "enterControl", timeout
+        # Reset motor and communication power breakers bits and cRIO interlock
+        # bit. Based on the original developer in ts_mtm2, this is required to
+        # make the power system works correctly.
+
+        # TODO: Check with electrical engineer that I need to reset the cRIO
+        # interlock or not in a latter time.
+        for idx in range(2, 5):
+            await self._execute_command(
+                self.controller_cell.set_bit_digital_status,
+                idx,
+                DigitalOutputStatus.BinaryHighLevel,
+            )
+
+        # I don't understand why I need to put the CLC mode to be Idle twice.
+        # This is translated from the ts_mtm2 and I need this to make the M2
+        # cRIO simulator to work.
+        await self._execute_command(
+            self.controller_cell.set_closed_loop_control_mode,
+            ClosedLoopControlMode.Idle,
         )
 
-        await self._transition_controller_state(salobj.State.STANDBY, "start", timeout)
-        await self._transition_controller_state(
-            salobj.State.DISABLED, "enable", timeout
+        await self._execute_command(
+            self.controller_cell.load_configuration,
         )
+        await self._execute_command(
+            self.controller_cell.set_control_parameters,
+        )
+
+        await self._execute_command(
+            self.controller_cell.set_closed_loop_control_mode,
+            ClosedLoopControlMode.Idle,
+        )
+        await self._execute_command(
+            self.controller_cell.reset_force_offsets,
+        )
+        await self._execute_command(
+            self.controller_cell.reset_actuator_steps,
+        )
+
+        # Power on the system and enable the ILCs
+        await self._execute_command(
+            self.controller_cell.power,
+            PowerType.Communication,
+            True,
+            timeout=self.COMMAND_TIMEOUT_LONG,
+        )
+        await self._execute_command(
+            self.controller_cell.power,
+            PowerType.Motor,
+            True,
+            timeout=self.COMMAND_TIMEOUT_LONG,
+        )
+
+        if not self.controller_cell.are_ilc_modes_enabled():
+            try:
+                await self._execute_command(
+                    self.controller_cell.set_ilc_to_enabled,
+                    timeout=self.ilc_timeout,
+                    retry_times=self.ilc_retry_times,  # type: ignore[arg-type]
+                )
+
+            except RuntimeError:
+                # TODO: Publish the list of failed ILCs after the DM-40146 is
+                # done.
+                await self._basic_cleanup_and_power_off_motor()
+                raise
+
+        await self._execute_command(
+            self.controller_cell.set_closed_loop_control_mode,
+            ClosedLoopControlMode.OpenLoop,
+            timeout=self.COMMAND_TIMEOUT_LONG,
+        )
+
+        # Wait for some time before transitioning to the closed-loop control
+        await asyncio.sleep(self.SLEEP_TIME_SHORT)
+
+        await self._switch_force_balance_system(True)
+
+        # Wait for some time to stabilize the system
+        await asyncio.sleep(self.SLEEP_TIME_SHORT)
+
+        # System is ready now. If there is any error, the system will
+        # transition to the Fault state from now on.
+        self.system_is_ready = True
 
         await super().do_enable(data)
+
+    async def _bypass_monitor_ilc_read_error(self) -> None:
+        """Bypass the error codes related to the monitoring inner-loop
+        controller (ILC) read error before the fix.
+
+        TODO: Remove this after the ILC is fixed.
+        """
+
+        codes = {1000, 1001, 6052}
+        (
+            enabled_faults_mask,
+            bits,
+        ) = self.controller_cell.error_handler.calc_enabled_faults_mask(
+            codes, DEFAULT_ENABLED_FAULTS_MASK
+        )
+        self.log.info(f"Bypass the error codes: {codes}. Bits: {bits}.")
+
+        await self._execute_command(
+            self.controller_cell.set_enabled_faults_mask,
+            enabled_faults_mask,
+        )
+
+    async def _basic_cleanup_and_power_off_motor(self) -> None:
+        """Basic cleanup and power off the motor."""
+
+        try:
+            await self._execute_command(
+                self.controller_cell.reset_force_offsets,
+            )
+            await self._execute_command(
+                self.controller_cell.reset_actuator_steps,
+            )
+
+            await self._execute_command(
+                self.controller_cell.set_closed_loop_control_mode,
+                ClosedLoopControlMode.TelemetryOnly,
+                timeout=self.COMMAND_TIMEOUT_LONG,
+            )
+
+            await self._execute_command(
+                self.controller_cell.power,
+                PowerType.Motor,
+                False,
+                timeout=self.COMMAND_TIMEOUT_LONG,
+            )
+
+        except Exception:
+            self.log.exception(
+                "Error when doing the basic cleanup and power off the motor."
+            )
+
+    async def _switch_force_balance_system(
+        self, status: bool, timeout: float | None = None
+    ) -> None:
+        """Switch the force balance system.
+
+        Parameters
+        ----------
+        status : `bool`
+            True if turn on the force balance system. Otherwise, False.
+        timeout : `float` or None, optional
+            Timeout of command in second. If None, the default value is used.
+            (the default is None)
+        """
+
+        # Do not allow the open-loop max limit in the closed-loop control
+        if status is True:
+            await self._execute_command(
+                self.controller_cell.enable_open_loop_max_limit, False, timeout=timeout
+            )
+
+        await self._execute_command(
+            self.controller_cell.switch_force_balance_system, status, timeout=timeout
+        )
 
     async def begin_disable(self, data: salobj.BaseMsgType) -> None:
         # multiply timeout by 3 as this is the number of commands executed with
@@ -391,74 +601,15 @@ class M2(salobj.ConfigurableCsc):
         await super().begin_disable(data)
 
     async def do_disable(self, data: salobj.BaseMsgType) -> None:
-        timeout = self.COMMAND_TIMEOUT
+        # By doing this, we can avoid the new error code put the system into
+        # the Fault state again, which is annoying.
+        self.system_is_ready = False
+        await asyncio.sleep(self.SLEEP_TIME_SHORT)
 
-        await self._transition_controller_state(
-            salobj.State.ENABLED, "disable", timeout
-        )
-
-        await self._transition_controller_state(
-            salobj.State.DISABLED, "standby", timeout
-        )
-        await self._transition_controller_state(
-            salobj.State.STANDBY, "exitControl", timeout
-        )
+        await self._switch_force_balance_system(False)
+        await self._basic_cleanup_and_power_off_motor()
 
         await super().do_disable(data)
-
-    async def _transition_controller_state(
-        self, state_original: salobj.State, message_name: str, timeout: float
-    ) -> None:
-        """Transition the controller's state if possible.
-
-        This function will only do the transition if the controller'state right
-        now equals the state_original. Otherwise, nothing will happen.
-
-        Parameters
-        ----------
-        state_original : `lsst.ts.salobj.State`
-            Original controller's state.
-        message_name : `str`
-            Message name to do the state transition.
-        timeout : `float`
-            Timeout of command in second.
-
-        Raises
-        ------
-        `ValueError`
-            If the command (message_name) is not supported.
-        """
-
-        if message_name == "enterControl":
-            state_target = salobj.State.STANDBY
-        elif message_name == "start":
-            state_target = salobj.State.DISABLED
-        elif message_name == "enable":
-            state_target = salobj.State.ENABLED
-        elif message_name == "disable":
-            state_target = salobj.State.DISABLED
-        elif message_name == "standby":
-            state_target = salobj.State.STANDBY
-        elif message_name == "exitControl":
-            state_target = salobj.State.OFFLINE
-        else:
-            raise ValueError(f"{message_name} command is not supported.")
-
-        try:
-            if self.controller_cell.controller_state == state_original:
-                await self.controller_cell.write_command_to_server(
-                    message_name,
-                    timeout=timeout,
-                    controller_state_expected=state_target,
-                )
-
-        except OSError:
-            await self.controller_cell.close()
-
-            await self.fault(
-                code=ErrorCode.NoConnection,
-                report="Lost the TCP/IP connection.",
-            )
 
     async def do_applyForces(self, data: salobj.BaseMsgType) -> None:
         """Apply force.
@@ -468,9 +619,10 @@ class M2(salobj.ConfigurableCsc):
         data : `object`
             Data of the SAL message.
         """
-        await self.cmd_applyForces.ack_in_progress(data, timeout=self.COMMAND_TIMEOUT)
 
-        self._assert_enabled_csc_and_controller("applyForces", [salobj.State.ENABLED])
+        self._assert_enabled_and_closed_loop_control()
+
+        await self.cmd_applyForces.ack_in_progress(data, timeout=self.COMMAND_TIMEOUT)
 
         force_axial = data.axial
         force_tangent = data.tangent
@@ -481,6 +633,22 @@ class M2(salobj.ConfigurableCsc):
             force_axial,
             force_tangent,
         )
+
+    def _assert_enabled_and_closed_loop_control(self) -> None:
+        """Assert the system is in the Enabled state and under the closed-loop
+        control or not.
+
+        Raises
+        -------
+        `RuntimeError`
+            If the system is not under the closed-loop control.
+        """
+
+        self.assert_enabled()
+
+        closed_loop = ClosedLoopControlMode.ClosedLoop
+        if self.controller_cell.closed_loop_control_mode != closed_loop:
+            raise RuntimeError(f"System needs to be under {closed_loop!r}.")
 
     def _check_applied_forces_in_range(
         self,
@@ -538,12 +706,11 @@ class M2(salobj.ConfigurableCsc):
         data : `object`
             Data of the SAL message.
         """
+
+        self._assert_enabled_and_closed_loop_control()
+
         await self.cmd_positionMirror.ack_in_progress(
             data, timeout=self.COMMAND_TIMEOUT
-        )
-
-        self._assert_enabled_csc_and_controller(
-            "positionMirror", [salobj.State.ENABLED]
         )
 
         await self._execute_command(
@@ -564,12 +731,11 @@ class M2(salobj.ConfigurableCsc):
         data : `object`
             Data of the SAL message.
         """
+
+        self._assert_enabled_and_closed_loop_control()
+
         await self.cmd_resetForceOffsets.ack_in_progress(
             data, timeout=self.COMMAND_TIMEOUT
-        )
-
-        self._assert_enabled_csc_and_controller(
-            "resetForceOffsets", [salobj.State.ENABLED]
         )
 
         await self._execute_command(
@@ -590,17 +756,9 @@ class M2(salobj.ConfigurableCsc):
     async def _clear_controller_errors(self) -> None:
         """Clear the controller errors."""
 
-        try:
-            await self.controller_cell.clear_errors()
-
-        except OSError:
-            await self.controller_cell.close()
-
-            if self.disabled_or_enabled:
-                await self.fault(
-                    code=ErrorCode.NoConnection,
-                    report="Lost the TCP/IP connection.",
-                )
+        await self._execute_command(
+            self.controller_cell.clear_errors, bypass_state_checking=True  # type: ignore[arg-type]
+        )
 
     async def do_selectInclinationSource(self, data: salobj.BaseMsgType) -> None:
         """Command to select source of inclination data.
@@ -610,12 +768,11 @@ class M2(salobj.ConfigurableCsc):
         data : `object`
             Data of the SAL message.
         """
+
+        self._assert_disabled()
+
         await self.cmd_selectInclinationSource.ack_in_progress(
             data, timeout=self.COMMAND_TIMEOUT
-        )
-
-        self._assert_enabled_csc_and_controller(
-            "selectInclinationSource", [salobj.State.ENABLED]
         )
 
         source = MTM2.InclinationTelemetrySource(data.source)
@@ -628,6 +785,19 @@ class M2(salobj.ConfigurableCsc):
 
         await self._execute_command(self.controller_cell.set_control_parameters)
 
+    def _assert_disabled(self) -> None:
+        """Assert that an action that requires DISABLED state can be run.
+
+        Raises
+        ------
+        `RuntimeError`
+            When the system is not in DISABLED state.
+        """
+
+        disabled_state = salobj.State.DISABLED
+        if self.summary_state != disabled_state:
+            raise RuntimeError(f"Only allowed in the {disabled_state!r}")
+
     async def do_setTemperatureOffset(self, data: salobj.BaseMsgType) -> None:
         """Command to set temperature offset for the LUT temperature
         correction.
@@ -637,12 +807,11 @@ class M2(salobj.ConfigurableCsc):
         data : `object`
             Data of the SAL message.
         """
+
+        self._assert_disabled()
+
         await self.cmd_setTemperatureOffset.ack_in_progress(
             data, timeout=self.COMMAND_TIMEOUT
-        )
-
-        self._assert_enabled_csc_and_controller(
-            "setTemperatureOffset", [salobj.State.ENABLED]
         )
 
         await self._execute_command(
@@ -660,33 +829,14 @@ class M2(salobj.ConfigurableCsc):
         data : `object`
             Data of the SAL message.
         """
+
+        self.assert_enabled()
+
         await self.cmd_switchForceBalanceSystem.ack_in_progress(
             data, timeout=self.COMMAND_TIMEOUT
         )
 
-        self._assert_enabled_csc_and_controller(
-            "switchForceBalanceSystem", [salobj.State.ENABLED]
-        )
-
-        await self._execute_command(
-            self.controller_cell.switch_force_balance_system,
-            data.status,
-        )
-
-    def _assert_enabled_csc_and_controller(
-        self, message_name: str, allowed_curr_states: typing.List[salobj.State]
-    ) -> None:
-        """Assert the CSC and controller are in ENABLED state.
-
-        Parameters
-        ----------
-        command_name : `str`
-            Command name.
-        allowed_curr_states : `list [lsst.ts.salobj.State]`
-            Allowed current states.
-        """
-        self.controller_cell.assert_controller_state(message_name, allowed_curr_states)
-        self.assert_enabled()
+        await self._switch_force_balance_system(data.status)
 
     async def _execute_command(
         self,
@@ -723,10 +873,11 @@ class M2(salobj.ConfigurableCsc):
             self.log.exception("Connection error executing command.")
             await self.controller_cell.close()
 
-            await self.fault(
-                code=ErrorCode.NoConnection,
-                report="Lost the TCP/IP connection.",
-            )
+            if self.disabled_or_enabled:
+                await self.fault(
+                    code=ErrorCode.NoConnection,
+                    report="Lost the TCP/IP connection.",
+                )
 
     @staticmethod
     def get_config_pkg() -> str:

--- a/python/lsst/ts/m2/csc.py
+++ b/python/lsst/ts/m2/csc.py
@@ -526,14 +526,14 @@ class M2(salobj.ConfigurableCsc):
         TODO: Remove this after the ILC is fixed.
         """
 
-        codes = {1000, 1001, 6052}
+        ilc_codes_to_bypass = {1000, 1001, 6052}
         (
             enabled_faults_mask,
             bits,
         ) = self.controller_cell.error_handler.calc_enabled_faults_mask(
-            codes, DEFAULT_ENABLED_FAULTS_MASK
+            ilc_codes_to_bypass, DEFAULT_ENABLED_FAULTS_MASK
         )
-        self.log.info(f"Bypass the error codes: {codes}. Bits: {bits}.")
+        self.log.info(f"Bypass the error codes: {ilc_codes_to_bypass}. Bits: {bits}.")
 
         await self._execute_command(
             self.controller_cell.set_enabled_faults_mask,

--- a/python/lsst/ts/m2/enum.py
+++ b/python/lsst/ts/m2/enum.py
@@ -27,3 +27,4 @@ __all__ = ["ErrorCode"]
 class ErrorCode(IntEnum):
     ControllerInFault = 1
     NoConnection = auto()
+    InterlockEngaged = auto()

--- a/python/lsst/ts/m2/translator.py
+++ b/python/lsst/ts/m2/translator.py
@@ -48,6 +48,8 @@ class Translator:
             message_reformat = self._handle_tangent_force(message_reformat)
         elif message_name == "summaryState":
             message_reformat = self._handle_summary_state(message_reformat)
+        elif message_name == "commandableByDDS":
+            message_reformat = self._handle_commandable_by_dds(message_reformat)
 
         return message_reformat
 
@@ -68,7 +70,7 @@ class Translator:
             Reformated message.
         """
 
-        message["lutTemperature"] = [0] * 6
+        message["lutTemperature"] = [0.0] * 6
 
         return message
 
@@ -85,8 +87,30 @@ class Translator:
 
         Returns
         -------
-        message : `dict`
+        `dict`
             Reformated message.
         """
 
         return dict(id="controllerState", controllerState=message["summaryState"])
+
+    def _handle_commandable_by_dds(self, message: dict) -> dict:
+        """Handle the message of commandable by data distribution system (DDS).
+
+        TODO: Remove this function after the DM-37422 is fixed. At this moment,
+        we need to connect the CSC to the ports of GUI to establish the
+        TCP/IP connection.
+
+        Parameters
+        ----------
+        message : `dict`
+            Message from the component.
+
+        Returns
+        -------
+        message : `dict`
+            Reformated message.
+        """
+
+        message["state"] = True
+
+        return message

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -43,6 +43,13 @@ class TestTranslator(unittest.TestCase):
         self.assertEqual(message_payload["id"], "controllerState")
         self.assertEqual(message_payload["controllerState"], 3)
 
+    def test_handle_commandable_by_dds(self) -> None:
+        message = dict(id="commandableByDDS", state=False)
+
+        message_payload = self.translator.translate(message)
+
+        self.assertTrue(message_payload["state"])
+
 
 if __name__ == "__main__":
     # Do the unit test


### PR DESCRIPTION
* Remove the ``M2.set_mount_elevation_in_position_callback()``.
* Ignore the events and telemetry that are not in **ts_xml** temporarily.
* Communicate with the cRIO directly.
* Add the enum field: ``ErrorCode.InterlockEngaged``.