### PR TITLE
Update the conda recipe and publish the bypassedIlc event.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,7 +14,7 @@ build:
 
 test:
   requires:
-    - ts-conda-build
+    - ts-conda-build =0.4
     - ts-simactuators
     - ts-xml
     - ts-idl {{ idl_version }}
@@ -42,7 +42,7 @@ requirements:
     - python {{ python }}
     - setuptools_scm
     - setuptools
-    - ts-conda-build =0.3
+    - ts-conda-build =0.4
   run:
     - python {{ python }}
     - setuptools

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,14 @@
 Version History
 ===============
 
+v0.12.5
+-------
+
+* Update the version of ts-conda-build to 0.4 in the conda recipe.
+* Use the **ILC_READ_WARNING_ERROR_CODES** from **ts_m2com**.
+* Publish the disabled/bypassed ILC event.
+* Remove the code related to the backward compatibily of **ts_xml** v20.1.0.
+
 v0.12.4
 -------
 

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -9,6 +9,7 @@ v0.12.5
 * Use the **ILC_READ_WARNING_ERROR_CODES** from **ts_m2com**.
 * Publish the disabled/bypassed ILC event.
 * Remove the code related to the backward compatibily of **ts_xml** v20.1.0.
+* Allow the set of hardpoints.
 
 v0.12.4
 -------

--- a/python/lsst/ts/m2/csc.py
+++ b/python/lsst/ts/m2/csc.py
@@ -1683,20 +1683,14 @@ class M2(salobj.ConfigurableCsc):
             hardpoints[NUM_HARDPOINTS_AXIAL:],
         )
 
-        if self.simulation_mode == 1:
-            await self.cmd_setHardpointList.ack_in_progress(
-                data, timeout=self.COMMAND_TIMEOUT
-            )
+        await self.cmd_setHardpointList.ack_in_progress(
+            data, timeout=self.COMMAND_TIMEOUT
+        )
 
-            await self._execute_command(
-                self.controller_cell.set_hardpoint_list,
-                hardpoints,
-            )
-
-        else:
-            # TODO: Support this after the update of M2 cell LabVIEW code is
-            # done.
-            raise NotImplementedError("Command is not supported yet.")
+        await self._execute_command(
+            self.controller_cell.set_hardpoint_list,
+            hardpoints,
+        )
 
     async def _execute_command(
         self,


### PR DESCRIPTION
* Update the version of ts-conda-build to 0.4 in the conda recipe.
* Use the **ILC_READ_WARNING_ERROR_CODES** from **ts_m2com**.
* Publish the bypassed ILC event.
* Remove the code related to the backward compatibily of **ts_xml** v20.1.0.